### PR TITLE
Set cont-type header before get_callback_info

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -518,8 +518,8 @@ class Call(object):
         return -- Response() -- the response object, populated with info from running the controller
         '''
         try:
-            callback, callback_args, callback_kwargs = self.get_callback_info()
             self.response.headers['Content-Type'] = self.content_type
+            callback, callback_args, callback_kwargs = self.get_callback_info()
             body = callback(*callback_args, **callback_kwargs)
             self.response.body = body
 


### PR DESCRIPTION
The purpose of this PR is to allow more flexibility for setting the "Content-Type" header inside of controllers.

If the "Content-Type" header is set prior to get_callback_info, I can set the "Content-Type" header for a full controller inside the __init__ method

```
class Default(Controller):
"""
HTML response route handling
"""
def __init__(self, request, response):
    """
    Set Content-Type header to application/json
    """
    super(Default, self).__init__(request, response)
    self.response.headers['Content-Type'] = "text/html"
```
