### PR TITLE
Boolean fix

### DIFF
--- a/endpoints/decorators.py
+++ b/endpoints/decorators.py
@@ -250,7 +250,7 @@ class param(object):
                 if val not in pchoices:
                     raise CallError(400, "param {} with value {} not in choices {}".format(name, val, pchoices))
 
-            if not allow_empty and not val:
+            if not allow_empty and not val is False and not val:
                 if 'default' not in flags:
                     raise CallError(400, "param {} was empty".format(name))
 

--- a/endpoints_test.py
+++ b/endpoints_test.py
@@ -1741,6 +1741,13 @@ class DecoratorsTest(TestCase):
         r = foo(c, **{'foo': '0'})
         self.assertEqual(False, r)
 
+        @endpoints.decorators.param('bar', type=bool, require=True)
+        def bar(self, *args, **kwargs):
+            return kwargs['bar']
+
+        r = bar(c, **{'bar': 'False'})
+        self.assertEqual(False, r)
+
     def test_param_list(self):
         c = create_controller()
 


### PR DESCRIPTION
Error thrown

```
File "/usr/local/lib/python2.7/dist-packages/endpoints/decorators.py", line 255, in normalize_param
    raise CallError(400, "param {} was empty".format(name))
```

with decorator

```
@endpoints.decorators.param('param', type=bool, require=True)
```

when param value is `False`