### PR TITLE
Fix another bug in IP regex.

### DIFF
--- a/endpoints/http.py
+++ b/endpoints/http.py
@@ -715,11 +715,12 @@ class Request(Http):
         # https://github.com/un33k/django-ipware
         # http://www.ietf.org/rfc/rfc3330.txt (IPv4)
         # http://www.ietf.org/rfc/rfc5156.txt (IPv6)
+        # https://en.wikipedia.org/wiki/Reserved_IP_addresses
         regex = re.compile(ur'^(?:{})'.format(ur'|'.join([
             ur'0\.', # reserved for 'self-identification'
             ur'10\.', # class A
             ur'169\.254', # link local block
-            ur'172\.(?:1[6-9]|2[0-9]|3[0-1])', # class B
+            ur'172\.(?:1[6-9]|2[0-9]|3[0-1])\.', # class B
             ur'192\.0\.2', # documentation/examples
             ur'192\.168', # class C
             ur'255\.{3}', # broadcast address

--- a/tests/http_test.py
+++ b/tests/http_test.py
@@ -124,18 +124,23 @@ class RequestTest(TestCase):
 
     def test_ip(self):
         r = Request()
+        r.set_header('REMOTE_ADDR', '172.252.0.1')
+        self.assertEqual('172.252.0.1', r.ip)
+
+        r = Request()
+        r.set_header('REMOTE_ADDR', '1.241.34.107')
+        self.assertEqual('1.241.34.107', r.ip)
+
+        r = Request()
         r.set_header('x-forwarded-for', '54.241.34.107')
-        ip = r.ip
-        self.assertEqual('54.241.34.107', ip)
+        self.assertEqual('54.241.34.107', r.ip)
 
         r.set_header('x-forwarded-for', '127.0.0.1, 54.241.34.107')
-        ip = r.ip
-        self.assertEqual('54.241.34.107', ip)
+        self.assertEqual('54.241.34.107', r.ip)
 
         r.set_header('x-forwarded-for', '127.0.0.1')
         r.set_header('client-ip', '54.241.34.107')
-        ip = r.ip
-        self.assertEqual('54.241.34.107', ip)
+        self.assertEqual('54.241.34.107', r.ip)
 
     def test_body_kwargs_bad_content_type(self):
         """make sure a form upload content type with json body fails correctly"""


### PR DESCRIPTION
The previous rule incorrectly matches thing like 172.160.*.*
because it didn't require the addition '.' after the first 2
digits in the second octet.